### PR TITLE
chore: remove conflicting eslint indent rule and whitespce in README.md

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,6 @@
           "afterColon": true
         }
       ],
-      "indent": ["error", 2],
       "react/require-default-props": [2, { "forbidDefaultForRequired": true }],
       "react/prop-types": [
         2,

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ npm run fix
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ### Financial Contributors


### PR DESCRIPTION
<!-- Love osca? Please consider supporting our collective:
👉  https://opencollective.com/osca/donate -->

#### What does this PR do
Address conflicting `eslint` and `prettier` indent rules.
Removing indent rules within `.eslintrc` in favour of prettier.
- prettier format automatically address indenting issue following the `.editorconfig` specifications.

#### Description of Task to be completed

#### How should this be manually tested
Break an indentation and run `npm run fix`

#### What are the relevant issues this PR belongs to

#<NUMBER>

#### Any background context you want to add

#### Screenshots
<img width="631" alt="Screenshot 2020-01-08 at 14 36 13" src="https://user-images.githubusercontent.com/29008971/71982260-51c07400-3224-11ea-803f-8311f044630c.png">
